### PR TITLE
Fix add task failure handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,16 +35,17 @@ function addItem() {
     }
 
     const list = document.getElementById("groceryList");
-    shoppingList.addItem(itemText, userName).then(({ data: [{ id, name, created_at }], error }) => {
-        if (error) {
-            alert("Could not insert item. Please try again?")
+    shoppingList.addItem(itemText, userName).then(({ data, error }) => {
+        if (error || !data) {
+            alert("Could not insert item. Please try again?");
         } else {
-            const li = makeItemElement(id, name, created_at, userName)
+            const [{ id, name, created_at }] = data;
+            const li = makeItemElement(id, name, created_at, userName);
             list.prepend(li); // Adds new item to the top of the list
-            onItemChangesCompleted()
+            onItemChangesCompleted();
             input.value = "";
         }
-    })
+    });
 }
 
 // ✅ New function to format timestamps as "today", "1 day ago", "2 days ago", "1 week ago"

--- a/tasks.js
+++ b/tasks.js
@@ -23,10 +23,11 @@ function addTask() {
     }
 
     const list = document.getElementById("taskList")
-    dailyTaskList.addItem(itemText, userName).then(({ data: [{ id, name, created_at }], error }) => {
-        if (error) {
+    dailyTaskList.addItem(itemText, userName).then(({ data, error }) => {
+        if (error || !data) {
             alert("Could not insert task. Please try again?")
         } else {
+            const [{ id, name, created_at }] = data
             const li = makeTaskElement(id, name, created_at, userName)
             list.prepend(li)
             onTaskChangesCompleted()


### PR DESCRIPTION
## Summary
- handle possible insertion errors for tasks
- mirror the same error handling for grocery items

## Testing
- `node -c tasks.js`
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_686349b16e80832f99cd2972828d50d1